### PR TITLE
Fix Handler.pm deleteMail

### DIFF
--- a/src/Handler.pm
+++ b/src/Handler.pm
@@ -219,6 +219,8 @@ sub deleteMail
             $data->{'MAIL_ADDR'}
         );
 
+        local $CWD = $::imscpConfig{'GUI_ROOT_DIR'};
+
         # Remove unwanted characters from the email (Mimic RainLoop behavior)
         ( my $email = $data->{'MAIL_ADDR'} ) =~ s/[^a-z0-9\-\.@]+/_/i;
         my $storageRootDir = "$CWD/data/persistent/rainloop/imscp/storage";
@@ -229,14 +231,17 @@ sub deleteMail
             # (Mimic RainLoop behavior)
             my $storageSubDir = substr( $email, 0, 2 ) =~ s/\@$//r;
             $storageSubDir .= ( '_' x ( 2-length( $storageSubDir ) ) );
-            my $storagePath = $storageRootDir . '/' . $storageType . '/'
-                . $storageSubDir . '/' . $email . '/';
-
-            iMSCP::Dir->new( dirname => $storagePath )->remove();
-            my $dir = iMSCP::Dir->new( dirname => $storageRootDir . '/'
-                . $storageType . '/' . $storageSubDir );
-            next unless $dir->isEmpty();
-            $dir->remove();
+            my $storageSubPath = $storageRootDir . '/' . $storageType . '.'
+                . $storageSubDir;
+            my $storagePath = $storageSubPath . '/' . $email . '/';
+            if (-d $storagePath) {
+                iMSCP::Dir->new( dirname => $storagePath )->remove();
+            }
+            my $dir = iMSCP::Dir->new( dirname => $storageSubPath );
+            next unless (-d $storageSubPath && $dir->isEmpty());
+            if (-d $storageSubPath) {
+                $dir->remove();
+            }
         }
     };
     if ( $@ ) {


### PR DESCRIPTION
When used with 1.5.3-maintenance branch Handler.pm deleteMail results in two errors:

1) $CWD is not initialized so the folders cannot be found.
2) If the folders do not exist (which they may not) then iMSCP::Dir raises an error "dir not found" whilst trying to delete the directory.

- Add $CWD in deleteMail
- Check that folders exist before attempting to delete them.
  Failing to do this causes iMSCP::Dir to error.